### PR TITLE
BREAKING CHANGE: `dynamoExpr` returns an object instead of a tuple

### DIFF
--- a/src/dynamo-expr.ts
+++ b/src/dynamo-expr.ts
@@ -1,22 +1,34 @@
 import { DynamoAttributeValue } from "@aws-cdk/aws-stepfunctions-tasks";
 import { refCounter } from "./counter";
 
+export interface ExpressionAggregate {
+  /**
+   * Built expression that contains calculated placeholders.
+   */
+  readonly expression: string;
+
+  /**
+   * attribute values that used to substitute expression's placeholders by DynamoDB.
+   */
+  readonly expressionAttributeValues: { [key: string]: DynamoAttributeValue };
+}
+
 /**
  * Builds an expression and expression attribute values from template string.
  */
 export const dynamoExpr = (
   literals: TemplateStringsArray,
   ...placeholers: DynamoAttributeValue[]
-): [expr: string, values: { [key: string]: DynamoAttributeValue }] => {
+): ExpressionAggregate => {
   let expression = "";
-  const vs: { [key: string]: DynamoAttributeValue } = {};
+  const expressionAttributeValues: { [key: string]: DynamoAttributeValue } = {};
   placeholers.forEach((pv, idx) => {
     const { value } = refCounter.next();
     const ref = `:v${value}`;
     expression += literals[idx];
     expression += ref;
-    vs[ref] = pv;
+    expressionAttributeValues[ref] = pv;
   });
   expression += literals[literals.length - 1];
-  return [expression, vs];
+  return { expression, expressionAttributeValues };
 };

--- a/test/dynamo-expr.test.ts
+++ b/test/dynamo-expr.test.ts
@@ -8,10 +8,10 @@ describe("dynamoExpr", () => {
   });
 
   test("simple", () => {
-    const [
+    const {
       expression,
       expressionAttributeValues,
-    ] = dynamoExpr`SET Executing = ${DynamoAttributeValue.fromBoolean(true)}`;
+    } = dynamoExpr`SET Executing = ${DynamoAttributeValue.fromBoolean(true)}`;
     expect(expression).toBe("SET Executing = :v1");
     expect(expressionAttributeValues).toStrictEqual({
       ":v1": DynamoAttributeValue.fromBoolean(true),
@@ -19,10 +19,10 @@ describe("dynamoExpr", () => {
   });
 
   test("multiple", () => {
-    const [
+    const {
       expression,
       expressionAttributeValues,
-    ] = dynamoExpr`SET V1 = ${DynamoAttributeValue.fromBoolean(
+    } = dynamoExpr`SET V1 = ${DynamoAttributeValue.fromBoolean(
       true
     )}, V2 = if_not_exists(V2, ${DynamoAttributeValue.fromNumber(10)})`;
     expect(expression).toBe("SET V1 = :v1, V2 = if_not_exists(V2, :v2)");


### PR DESCRIPTION
The `dynamoExpr` will be return more additional properties in near future.