### PR TITLE
fix: returns undefined instead empty object on expressionAttributeNames

### DIFF
--- a/src/dynamo-expr.ts
+++ b/src/dynamo-expr.ts
@@ -17,7 +17,7 @@ export interface ExpressionAggregate {
   /**
    * attribute names that used to substitute expression's placeholders by DynamoDB.
    */
-  readonly expressionAttributeNames: { [key: string]: DynamoAttributeName };
+  readonly expressionAttributeNames?: { [key: string]: DynamoAttributeName };
 }
 
 /**
@@ -63,6 +63,13 @@ export class ExpressionBuilder {
       }
     });
     expression += literals[literals.length - 1];
-    return { expression, expressionAttributeValues, expressionAttributeNames };
+    return {
+      expression,
+      expressionAttributeValues,
+      expressionAttributeNames:
+        Object.keys(expressionAttributeNames).length === 0
+          ? undefined
+          : expressionAttributeNames,
+    };
   }
 }

--- a/test/dynamo-expr.test.ts
+++ b/test/dynamo-expr.test.ts
@@ -7,9 +7,11 @@ describe("dynamoExpr", () => {
     const builder = new ExpressionBuilder();
     const {
       expression,
+      expressionAttributeNames,
       expressionAttributeValues,
     } = builder.expr`SET Executing = ${DynamoAttributeValue.fromBoolean(true)}`;
     expect(expression).toBe("SET Executing = :v0");
+    expect(expressionAttributeNames).toBeUndefined();
     expect(expressionAttributeValues).toStrictEqual({
       ":v0": DynamoAttributeValue.fromBoolean(true),
     });
@@ -19,11 +21,13 @@ describe("dynamoExpr", () => {
     const builder = new ExpressionBuilder();
     const {
       expression,
+      expressionAttributeNames,
       expressionAttributeValues,
     } = builder.expr`SET V1 = ${DynamoAttributeValue.fromBoolean(
       true
     )}, V2 = if_not_exists(V2, ${DynamoAttributeValue.fromNumber(10)})`;
     expect(expression).toBe("SET V1 = :v0, V2 = if_not_exists(V2, :v1)");
+    expect(expressionAttributeNames).toBeUndefined();
     expect(expressionAttributeValues).toStrictEqual({
       ":v0": DynamoAttributeValue.fromBoolean(true),
       ":v1": DynamoAttributeValue.fromNumber(10),


### PR DESCRIPTION
empty object is not allowed on expressionAttributeNames