### PR TITLE
build: create-release-pull-request job must be run after release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   create-release-pull-request:
-    needs: ci
+    needs: release
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
release job made a change to bump version